### PR TITLE
Enhance AntiTooExpensive functionality and update version to 1.1.11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     id("xyz.jpenilla.run-paper") version "3.0.2"
 }
 
-val yvtilsVersion = "1.1.9"
+val yvtilsVersion = "1.1.10"
 val jdaVersion = "5.6.1"
 val commandAPIVersion = "11.0.0"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,19 +2,21 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    kotlin("jvm") version "2.2.21"
-    kotlin("plugin.serialization") version "2.2.21"
+    val kotlinMonorepoVersion = "2.3.20"
 
-    id("com.gradleup.shadow") version "9.2.2"
+    kotlin("jvm") version kotlinMonorepoVersion
+    kotlin("plugin.serialization") version kotlinMonorepoVersion
 
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.19"
+    id("com.gradleup.shadow") version "9.4.1"
+
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
 
     id("xyz.jpenilla.run-paper") version "3.0.2"
 }
 
-val yvtilsVersion = "1.1.10"
+val yvtilsVersion = "1.1.11"
 val jdaVersion = "5.6.1"
-val commandAPIVersion = "11.0.0"
+val commandAPIVersion = "11.2.0"
 
 group = "yv.tils"
 version = yvtilsVersion
@@ -25,15 +27,13 @@ repositories {
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots/")
 }
 
-paperweight.reobfArtifactConfiguration.set(io.papermc.paperweight.userdev.ReobfArtifactConfiguration.MOJANG_PRODUCTION)
-
 dependencies {
     paperweight.paperDevBundle("1.21.4-R0.1-SNAPSHOT")
 
-    implementation("dev.jorel", "commandapi-paper-shade", commandAPIVersion)
-    implementation("dev.jorel", "commandapi-kotlin-paper", commandAPIVersion)
+    implementation("dev.jorel:commandapi-paper-shade:$commandAPIVersion")
+    implementation("dev.jorel:commandapi-kotlin-paper:$commandAPIVersion")
 
-    implementation("net.dv8tion", "JDA", jdaVersion)
+    implementation("net.dv8tion:JDA:$jdaVersion")
 }
 
 tasks.register("updateVersionFiles") {
@@ -68,12 +68,18 @@ tasks {
     }
 
     runServer {
-        minecraftVersion("1.21.9")
+        minecraftVersion("26.1.1")
     }
 }
 
 tasks.withType<KotlinCompile> {
     compilerOptions.jvmTarget.set(JvmTarget.JVM_21)
+}
+
+tasks.withType(xyz.jpenilla.runtask.task.AbstractRun::class) {
+    javaLauncher.set(project.extensions.getByType<JavaToolchainService>().launcherFor {
+        languageVersion.set(JavaLanguageVersion.of(25))
+    })
 }
 
 tasks.shadowJar {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/yv/tils/smp/manager/startup/Commands.kt
+++ b/src/main/kotlin/yv/tils/smp/manager/startup/Commands.kt
@@ -5,6 +5,7 @@ import yv.tils.smp.mods.admin.invSee.EcSee
 import yv.tils.smp.mods.admin.invSee.InvSee
 import yv.tils.smp.mods.admin.moderation.cmd.*
 import yv.tils.smp.mods.admin.vanish.VanishCMD
+import yv.tils.smp.mods.fusion.FusionCommand
 import yv.tils.smp.mods.fusionCrafting.FusionOverview
 import yv.tils.smp.mods.message.MSGCommand
 import yv.tils.smp.mods.message.ReplyCommand
@@ -57,7 +58,7 @@ class Commands {
      */
     private fun modulesCommands() {
         if (Config.config["modules.fusion"] as Boolean) {
-            FusionOverview()
+            FusionCommand()
         }
 
         if (Config.config["modules.status"] as Boolean) {

--- a/src/main/kotlin/yv/tils/smp/mods/fusion/FusionCommand.kt
+++ b/src/main/kotlin/yv/tils/smp/mods/fusion/FusionCommand.kt
@@ -1,0 +1,32 @@
+package yv.tils.smp.mods.fusion
+
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.kotlindsl.commandTree
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.jorel.commandapi.kotlindsl.stringArgument
+import yv.tils.smp.mods.fusionCrafting.FusionOverview
+
+class FusionCommand {
+    val command = commandTree("fusion") {
+        withPermission("yvtils.smp.command.fusion")
+        withUsage("/fusion")
+        withAliases("ccr", "fc")
+
+        stringArgument("manage", true) {
+            replaceSuggestions(
+                ArgumentSuggestions.strings(
+                    "manage"
+                )
+            )
+            withPermission("yvtils.smp.fusion.manage")
+
+            playerExecutor { sender, args ->
+                if (args[0] != "manage") {
+                    FusionOverview().openOverview(sender, "<gold>Fusion Crafting")
+                } else {
+                    FusionOverview().openOverview(sender, "<red>Fusion Management")
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/yv/tils/smp/mods/fusion/FusionOverview.kt
+++ b/src/main/kotlin/yv/tils/smp/mods/fusion/FusionOverview.kt
@@ -20,29 +20,6 @@ import yv.tils.smp.utils.inventory.GUIFiller
 import yv.tils.smp.utils.inventory.HeadUtils
 
 class FusionOverview {
-    val command = commandTree("fusion") {
-        withPermission("yvtils.smp.command.fusion")
-        withUsage("/fusion")
-        withAliases("ccr", "fc")
-
-        stringArgument("manage", true) {
-            replaceSuggestions(
-                ArgumentSuggestions.strings(
-                    "manage"
-                )
-            )
-            withPermission("yvtils.smp.fusion.manage")
-
-            playerExecutor { sender, args ->
-                if (args[0] != "manage") {
-                    openOverview(sender, "<gold>Fusion Crafting")
-                } else {
-                    openOverview(sender, "<red>Fusion Management")
-                }
-            }
-        }
-    }
-
     fun openOverview(player: Player, invTitle: String, page: Int = 1, tag: String = "") {
         if (page < 1) return
         if (fusionThumbnails.size - 24 * (page - 1) <= 0) return

--- a/src/main/kotlin/yv/tils/smp/mods/other/forging/AntiTooExpensive.kt
+++ b/src/main/kotlin/yv/tils/smp/mods/other/forging/AntiTooExpensive.kt
@@ -1,8 +1,10 @@
 package yv.tils.smp.mods.other.forging
 
+import org.bukkit.GameMode
 import org.bukkit.craftbukkit.inventory.CraftInventoryAnvil
 import org.bukkit.event.inventory.InventoryType
 import org.bukkit.event.inventory.PrepareAnvilEvent
+import yv.tils.smp.utils.color.ColorUtils
 import yv.tils.smp.utils.configs.global.Config
 
 class AntiTooExpensive {
@@ -17,5 +19,15 @@ class AntiTooExpensive {
         val inv = e.inventory as CraftInventoryAnvil
 
         inv.maximumRepairCost = Int.MAX_VALUE
+
+        if (inv.getItem(0) == null || inv.getItem(1) == null || inv.result == null) return
+
+        val player = (inv.viewers.firstOrNull())
+        if (player != null && player.gameMode != GameMode.CREATIVE) {
+            val price = inv.repairCost
+            player.sendMessage(ColorUtils().convert(
+                "<red>[AntiTooExpensive] <gray>Your anvil repair cost is <yellow>$price<gray> levels"
+            ))
+        }
     }
 }

--- a/src/main/kotlin/yv/tils/smp/utils/invSync/new/InvSyncOpen.kt
+++ b/src/main/kotlin/yv/tils/smp/utils/invSync/new/InvSyncOpen.kt
@@ -12,13 +12,9 @@ class InvSyncOpen {
 
         val isVanished = Vanish.vanish.containsKey(player.uniqueId) && Vanish.vanish[player.uniqueId]?.vanish ?: false
 
-        println("Location: ${e.inventory.location}")
-
         if (e.inventory.location == null) {
             return
         }
-
-        println("Vanished: $isVanished")
 
         if (isVanished) {
             val isSilentInteraction = Vanish.vanish[player.uniqueId]?.invInteraction ?: false

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: YVtils-SMP
-version: 1.1.8
+version: 1.1.10
 main: yv.tils.smp.YVtils
 api-version: '1.21'
 author: WolfiiYV

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -1,5 +1,5 @@
 name: YVtils-SMP
-version: 1.1.10
+version: 1.1.11
 main: yv.tils.smp.YVtils
 api-version: '1.21'
 author: WolfiiYV

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: YVtils-SMP
-version: 1.1.10
+version: 1.1.11
 main: yv.tils.smp.YVtils
 author: WolfiiYV
 api-version: "1.21"

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: YVtils-SMP
-version: 1.1.8
+version: 1.1.10
 main: yv.tils.smp.YVtils
 author: WolfiiYV
 api-version: "1.21"


### PR DESCRIPTION
This pull request introduces a new `FusionCommand` class to better organize and manage the fusion-related commands, updates the Gradle wrapper version, and includes minor improvements and cleanups in other parts of the codebase. The most significant changes are summarized below:

**Fusion Command Refactor and Improvements:**

* Introduced a new `FusionCommand` class to encapsulate the `/fusion` command logic, including permission handling, usage, aliases, and subcommands for managing and viewing fusion crafting. The command now delegates overview display to `FusionOverview` as appropriate.
* Updated the command registration in `Commands.kt` to use `FusionCommand` instead of directly instantiating `FusionOverview`, improving separation of concerns and maintainability.
* Removed the command registration logic from `FusionOverview.kt`, making it solely responsible for displaying GUIs, not handling command parsing.

**Dependency and Version Updates:**

* Upgraded the Gradle wrapper from version 9.1.0 to 9.4.1, ensuring compatibility with newer build features and plugins.
* Updated the plugin version in both `plugin.yml` and `paper-plugin.yml` from `1.1.8` to `1.1.11` to reflect the new release. [[1]](diffhunk://#diff-21d9405139b0003df9c66ea4d6f3af8d447c5d1b7b97e5d281f039dd752b7c1bL2-R2) [[2]](diffhunk://#diff-98201effe40eaf4a0e8826fadd6c5c9d5beaf9d737226b514f0853f44987a67fL2-R2)

**Other Improvements and Cleanups:**

* Enhanced the `AntiTooExpensive` class to provide player feedback on anvil repair costs when not in creative mode, improving user experience.
* Removed unnecessary debug print statements from `InvSyncOpen.kt` for cleaner logs.

closes #62 